### PR TITLE
Vibration API Recommendation errata

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,8 +105,8 @@
       </h2>
       <p>
         The concepts <dfn><a href=
-        "http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing
-        context</a></dfn> and <dfn><a href=
+        "https://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">top-level
+        browsing context</a></dfn> and <dfn><a href=
         "http://www.w3.org/TR/html5/webappapis.html#spin-the-event-loop">spin
         the event loop</a></dfn> are defined in [[!HTML5]].
       </p>
@@ -149,10 +149,10 @@
         <li>Let <var>valid pattern</var> be the result of passing
         <var>pattern</var> to <a>validate and normalize</a>.
         </li>
-        <li>If the <code><a href=
-        "http://dvcs.w3.org/hg/webperf/raw-file/tip/specs/PageVisibility/Overview.html#dom-document-hidden">
-          hidden</a></code> attribute [[!PAGE-VISIBILITY]] is set to true, then
-          return false and terminate these steps.
+        <li>If the result of running the steps to <a href=
+        "https://w3c.github.io/page-visibility/#dfn-steps-to-determine-if-the-document-is-hidden">
+          determine if the document is hidden</a> [[!PAGE-VISIBILITY]] is true,
+          then return false and terminate these steps.
           <div class="note">
             A trusted (also known as privileged) application that integrates
             closely with the operating system's functionality may vibrate the
@@ -222,11 +222,12 @@
       <ol>
         <li>An implementation MAY return false and terminate these steps.
           <div class="note">
-            For example, an implementation might abort the algorithm because
-            the user has set a preference indicating that pages at a given
-            origin should never be able to vibrate the device, or an
-            implementation might cap the total amount of time a page may cause
-            the device to vibrate and reject requests in excess of this limit.
+            For example, an implementation might abort the algorithm because no
+            vibration hardware is present, the user has set a preference
+            indicating that pages at a given origin should never be able to
+            vibrate the device, or an implementation might cap the total amount
+            of time a page may cause the device to vibrate and reject requests
+            in excess of this limit.
           </div>
         </li>
         <li>If another instance of the <a>perform vibration</a> algorithm is
@@ -255,12 +256,11 @@
         </li>
       </ol>
       <p>
-        When the <code><a href=
-        "http://dvcs.w3.org/hg/webperf/raw-file/tip/specs/PageVisibility/Overview.html#sec-visibilitychange-event">
-        visibilitychange</a></code> event [[!PAGE-VISIBILITY]] is dispatched at
-        the <code>Document</code> in a <a>browsing context</a>, the <a class=
-        "product-ua" href="#ua">user agent</a> MUST abort the already running
-        <a>processing vibration patterns</a> algorithm, if any.
+        When the user agent determines that the <a href=
+        "https://w3c.github.io/page-visibility/#dfn-visibility-states">visibility
+        state</a> of the <code>Document</code> of the <a>top-level browsing
+        context</a> changes, it MUST abort the already running <a>processing
+        vibration patterns</a> algorithm, if any.
       </p>
     </section>
     <section class='informative'>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,18 @@
               status:    "Living Standard",
               publisher: "WHATWG"
             }
-          }
+          },
+          otherLinks: [
+            {
+              key: 'Translation',
+              data: [
+                {
+                  value: '简体中文',
+                  href: 'https://w3c-html-ig-zh.github.io/vibration/'
+                }
+              ]
+            }
+          ]
       };
     </script>
   </head>
@@ -323,7 +334,8 @@
         providing the WebVibrator prototype as an initial input. Thanks to Anne
         van Kesteren for suggestions on how to make the specification reusable
         in other contexts, and to Lukasz Olejnik for the privacy
-        considerations.
+        considerations. Finally, thanks to Zhiqiang Zhang for the Simplified
+        Chinese translation.
       </p>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -276,9 +276,8 @@
         they provide a fingerprinting surface that can be exploited utilizing
         the vibration stimuli generated via the Vibration API. In this sense,
         Vibration API provides an indirect privacy risk, in conjunction with
-        other mechanisms. Additionally, in case the user intends to remain
-        anonymous, causing a device to vibrate might be visible to external
-        physical observers.
+        other mechanisms. Additionally, a device that is vibrating might be
+        visible to external observers and enable physical tracking of the user.
       </p>
     </section>
     <section class='informative'>

--- a/index.html
+++ b/index.html
@@ -263,6 +263,24 @@
         vibration patterns</a> algorithm, if any.
       </p>
     </section>
+    <section>
+      <h2>
+        Security and privacy considerations
+      </h2>
+      <p>
+        Vibration API is not a source of data on its own and as such is not
+        producing any data possible to consume on the Web. However, it is known
+        that it can serve as a source of events for other APIs. In particular,
+        it is known that certain sensors such as accelerometers or gyroscopes
+        are prone to tiny imperfections during their manufacturing. As such,
+        they provide a fingerprinting surface that can be exploited utilizing
+        the vibration stimuli generated via the Vibration API. In this sense,
+        Vibration API provides an indirect privacy risk, in conjunction with
+        other mechanisms. Additionally, in case the user intends to remain
+        anonymous, causing a device to vibrate might be visible to external
+        physical observers.
+      </p>
+    </section>
     <section class='informative'>
       <h2>
         Examples
@@ -305,7 +323,8 @@
         Sicking, and the Mozilla WebAPI team for their contributions, and for
         providing the WebVibrator prototype as an initial input. Thanks to Anne
         van Kesteren for suggestions on how to make the specification reusable
-        in other contexts.
+        in other contexts, and to Lukasz Olejnik for the privacy
+        considerations.
       </p>
     </section>
   </body>


### PR DESCRIPTION
These non-normative changes align the Vibration API spec with the
latest Page Visibility API spec by tapping into its hooks defined
post-Vibration API Recommendation publication:
- determine if the document is hidden
- visibility states

In addition, terminology is clarified as follows:
- browsing context -> top-level browsing context

The privacy and security considerations section was added

Link to the Simplified Chinese translation was added
