### PR TITLE
Fix ReSpec warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
           wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/43696/status",
           testSuiteURI: "https://w3c-test.org/vibration/",
           implementationReportURI: "https://w3c.github.io/test-results/vibration/20141118.html",
-          processVersion: 2015,
+          processVersion: 2017,
           localBiblio: {
             "NOTIFICATIONS": {
               title:     "Notifications API",
@@ -140,7 +140,7 @@
             boolean vibrate (VibratePattern pattern);
         };
       </pre>
-      <p link-for="Navigator">
+      <p data-link-for="Navigator">
         The <code><dfn data-dfn-for="Navigator">vibrate</dfn>()</code> method,
         when invoked, MUST run the algorithm for <a>processing vibration
         patterns</a>. A <dfn>vibration pattern</dfn> is represented by a
@@ -150,7 +150,7 @@
         The rules for <dfn>processing vibration patterns</dfn> are as given in
         the following algorithm:
       </p>
-      <ol link-for="Navigator">
+      <ol data-link-for="Navigator">
         <li>Let <var>pattern</var> be the first method argument of the
         <code><a>vibrate</a>()</code> method.
         </li>


### PR DESCRIPTION
Fixes the following ReSpec warnings:
```
Process 2015 has been superceded by Process 2017.
Found linkless element with text 'vibrate' but no matching <dfn>.
```

Editorial change, to be merged without review.
