### PR TITLE
Editorial: Fix ReSpec cite error

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
       <h2>
         Vibration Interface
       </h2>
-      <pre class="idl">
+      <pre class="idl" data-cite="HTML">
         typedef (unsigned long or sequence&lt;unsigned long&gt;) VibratePattern;
 
         partial interface Navigator {


### PR DESCRIPTION
Fixes error:
>Couldn't match "Navigator" to anything in the document or in any
>other document cited in this specification


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/pull/24.html" title="Last updated on Nov 13, 2019, 12:39 PM UTC (5726af3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/24/06a6b5d...5726af3.html" title="Last updated on Nov 13, 2019, 12:39 PM UTC (5726af3)">Diff</a>