### PR TITLE
respec: Migrate from the respec-w3c-common profile to respec-w3c.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
       Vibration API (Second Edition)
     </title>
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' async
     class='remove'>
     </script>
     <script class='remove'>
@@ -23,10 +23,8 @@
           ],
           inlineCSS:    true,
           noIDLIn:      true,
-          wg:           "Device and Sensors Working Group",
-          wgURI:        "https://www.w3.org/2009/dap/",
+          group:        "das",
           wgPublicList: "public-device-apis",
-          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/43696/status",
           testSuiteURI: "https://w3c-test.org/vibration/",
           implementationReportURI: "https://w3c.github.io/test-results/vibration/20141118.html",
           processVersion: 2017,


### PR DESCRIPTION
Fix a ReSpec warning and migrate to a profile that is not deprecated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/vibration/pull/26.html" title="Last updated on Jan 12, 2021, 9:48 AM UTC (9e828f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/26/b1c6b51...rakuco:9e828f3.html" title="Last updated on Jan 12, 2021, 9:48 AM UTC (9e828f3)">Diff</a>