### PR TITLE
Require sticky activation to perform vibrate

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,11 +120,16 @@
       <p>
         The concepts <dfn><a href=
         "https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level
-        browsing context</a></dfn> and <dfn><a href=
-        "https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop">spin
-        the event loop</a></dfn> and the <dfn><a href=
-        "https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object"><code>
-        Navigator</code></a></dfn> interface are defined in [[!HTML]].
+        browsing context</a></dfn>, <dfn><a href=
+        "https://html.spec.whatwg.org/#concept-relevant-global"><code>
+        relevant global object</code></a></dfn> and <dfn><a href=
+        "https://html.spec.whatwg.org/#sticky-activation"><code>
+        sticky activation</code></a></dfn>
+        are defined in [[!HTML]].
+      </p>
+      <p>
+        The concept <dfn><a href="https://webidl.spec.whatwg.org/#this">this</a></dfn>
+        is defined in [[!WEBIDL]].
       </p>
     </section>
     <section>
@@ -226,6 +231,10 @@
         steps:
       </p>
       <ol>
+        <li>
+          If <a>this</a>'s <a>relevant global object</a> does not have
+          <a>sticky activation</a>, return false and terminate these steps.
+        </li>
         <li>An implementation MAY return false and terminate these steps.
           <div class="note">
             For example, an implementation might abort the algorithm because no
@@ -262,7 +271,7 @@
         </li>
       </ol>
       <p>
-        When the user agent determines that the <a href=
+        When the <a>user agent</a> determines that the <a href=
         "https://w3c.github.io/page-visibility/#dfn-visibility-states">visibility
         state</a> of the <code>Document</code> of the <a>top-level browsing
         context</a> changes, it MUST abort the already running <a>processing
@@ -288,9 +297,9 @@
         enable physical identification, and possibly tracking of the user.
       </p>
       <p>
-        For these reasons, the user agent SHOULD inform the user when the API
-        is being used and provide a mechanism to disable the API (effectively
-        no-op), on a per-origin basis or globally.
+        For these reasons, the <a>user agent</a> SHOULD inform the user when
+        the API is being used and provide a mechanism to disable the API
+        (effectively no-op), on a per-origin basis or globally.
       </p>
     </section>
     <section class='informative'>

--- a/index.html
+++ b/index.html
@@ -144,9 +144,9 @@
         };
       </pre>
       <p data-link-for="Navigator">
-        The <code><dfn data-dfn-for="Navigator">vibrate</dfn>()</code> method,
-        when invoked, MUST run the algorithm for <a>processing vibration
-        patterns</a>. A <dfn>vibration pattern</dfn> is represented by a
+        The <code><dfn data-dfn-for="Navigator">vibrate</dfn>()</code> method
+        steps are to run the <a>processing vibration patterns</a> algorithm.
+        A <dfn>vibration pattern</dfn> is represented by a
         <dfn><code>VibratePattern</code></dfn> object.
       </p>
       <p>
@@ -172,7 +172,7 @@
           </div>
         </li>
         <li>
-          <a>Perform vibration</a> with <var>valid pattern</var>.
+          <a>Perform vibration</a> with <a>this</a> and <var>valid pattern</var>.
         </li>
       </ol>
       <p>
@@ -227,8 +227,8 @@
         </li>
       </ol>
       <p>
-        To <dfn>perform vibration</dfn> using <var>pattern</var>, run these
-        steps:
+        To <dfn>perform vibration</dfn> using <a>this</a> and <var>pattern</var>,
+        run these steps:
       </p>
       <ol>
         <li>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,9 @@
           testSuiteURI: "https://w3c-test.org/vibration/",
           implementationReportURI: "https://w3c.github.io/test-results/vibration/20141118.html",
           processVersion: 2017,
+          xref: {
+            profile: "web-platform"
+          },
           localBiblio: {
             "NOTIFICATIONS": {
               title:     "Notifications API",
@@ -111,25 +114,6 @@
         this specification must implement them in a manner consistent with the
         ECMAScript Bindings defined in the Web IDL specification [[!WEBIDL-1]],
         as this specification uses that specification and terminology.
-      </p>
-    </section>
-    <section>
-      <h2>
-        Terminology
-      </h2>
-      <p>
-        The concepts <dfn><a href=
-        "https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level
-        browsing context</a></dfn>, <dfn><a href=
-        "https://html.spec.whatwg.org/#concept-relevant-global"><code>
-        relevant global object</code></a></dfn> and <dfn><a href=
-        "https://html.spec.whatwg.org/#sticky-activation"><code>
-        sticky activation</code></a></dfn>
-        are defined in [[!HTML]].
-      </p>
-      <p>
-        The concept <dfn><a href="https://webidl.spec.whatwg.org/#this">this</a></dfn>
-        is defined in [[!WEBIDL]].
       </p>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -156,7 +156,8 @@
           </div>
         </li>
         <li>
-          <a>Perform vibration</a> with <a>this</a> and <var>valid pattern</var>.
+          <a>Perform vibration</a> with <a>this</a>'s <a>relevant global object
+          </a> and <var>valid pattern</var>.
         </li>
       </ol>
       <p>
@@ -211,13 +212,14 @@
         </li>
       </ol>
       <p>
-        To <dfn>perform vibration</dfn> using <a>this</a> and <var>pattern</var>,
+        To <dfn>perform vibration</dfn> using a <a>global object</a>
+        <var>global</var> and a <a>vibration pattern</a> <var>pattern</var>,
         run these steps:
       </p>
       <ol>
         <li>
-          If <a>this</a>'s <a>relevant global object</a> does not have
-          <a>sticky activation</a>, return false and terminate these steps.
+          If <var>global</var> does not have <a>sticky activation</a>,
+          return false and terminate these steps.
         </li>
         <li>An implementation MAY return false and terminate these steps.
           <div class="note">


### PR DESCRIPTION
Also:
- Add dfns: this, relevant global object, sticky activation
- Remove unused refs: spin the event loop, Navigator
- Link to the "user agent" dfn

(Future work: refactor to use the fancier ref syntax.)

Fix #29


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/pull/30.html" title="Last updated on May 30, 2022, 3:53 PM UTC (167cf3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/30/6f01538...167cf3c.html" title="Last updated on May 30, 2022, 3:53 PM UTC (167cf3c)">Diff</a>