### PR TITLE
Clean up `respecConfig` a bit.

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,15 +31,6 @@
           xref: {
             profile: "web-platform"
           },
-          localBiblio: {
-            "NOTIFICATIONS": {
-              title:     "Notifications API",
-              href:      "https://notifications.spec.whatwg.org/",
-              authors:    [ "Anne van Kesteren" ],
-              status:    "Living Standard",
-              publisher: "WHATWG"
-            }
-          },
           otherLinks: [
             {
               key: 'Translation',

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
           //publishDate:          "2014-12-09",
           previousPublishDate:  "2014-09-09",
           previousMaturity:     "CR",
-          edDraftURI:           "https://w3c.github.io/vibration/",
+          github:               "w3c/vibration",
           lcEnd:                "2014-07-24",
           prEnd:                "2015-01-20",
           editors:  [
@@ -38,27 +38,6 @@
                 {
                   value: '简体中文',
                   href: 'https://w3c-html-ig-zh.github.io/vibration/'
-                }
-              ]
-            },
-            {
-              key: "Participate",
-              data: [
-                {
-                  value: "public-device-apis@w3.org",
-                  href: "https://lists.w3.org/Archives/Public/public-device-apis/"
-                },
-                {
-                  value: "GitHub w3c/vibration",
-                  href: "https://github.com/w3c/vibration/"
-                },
-                {
-                  value: "GitHub w3c/vibration/issues",
-                  href: "https://github.com/w3c/vibration/issues"
-                },
-                {
-                  value: "GitHub w3c/vibration/commits",
-                  href: "https://github.com/w3c/vibration/commits/"
                 }
               ]
             }


### PR DESCRIPTION
* a9c20ae respec: Remove localBiblio.
* 5e2ec22 respec: Set github property.

The first commit removes the manual reference to the Notifications spec since we now set `xref` in `respecConfig`, and the second one sets the `github` property that allows us to remove the participation information we had in `otherLinks`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/vibration/pull/31.html" title="Last updated on Jun 1, 2022, 7:59 AM UTC (5e2ec22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/31/26a6ac0...rakuco:5e2ec22.html" title="Last updated on Jun 1, 2022, 7:59 AM UTC (5e2ec22)">Diff</a>