### PR TITLE
turn page-visibility-2 into WHATWG/HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,9 +114,7 @@
         <li>Let <var>valid pattern</var> be the result of passing
         <var>pattern</var> to <a>validate and normalize</a>.
         </li>
-        <li>If the result of running the steps to <a href=
-        "https://w3c.github.io/page-visibility/#dfn-steps-to-determine-the-visibility-state">
-          determine the visibility state</a> [[!PAGE-VISIBILITY-2]] is not
+        <li>If the <a>document</a>'s {{Document/visibilityState}} is not 
           <code>visible</code>, then return false and terminate these steps.
           <div class="note">
             A trusted (also known as privileged) application that integrates
@@ -227,9 +225,9 @@
         </li>
       </ol>
       <p>
-        When the <a>user agent</a> determines that the <a href=
-        "https://w3c.github.io/page-visibility/#dfn-visibility-states">visibility
-        state</a> of the <code>Document</code> of the <a>top-level browsing
+        When the <a>user agent</a> determines that 
+        the {{Document/visibilityState}} of 
+        the <code>Document</code> of the <a>top-level browsing
         context</a> changes, it MUST abort the already running <a>processing
         vibration patterns</a> algorithm, if any.
       </p>

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
         <li>Let <var>valid pattern</var> be the result of passing
         <var>pattern</var> to <a>validate and normalize</a>.
         </li>
-        <li>If the <a>document</a>'s {{Document/visibilityState}} is not 
+        <li>If the <a>document</a>'s [=Document/visibility state=] is not 
           <code>visible</code>, then return false and terminate these steps.
           <div class="note">
             A trusted (also known as privileged) application that integrates

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
       </ol>
       <p>
         When the <a>user agent</a> determines that 
-        the {{Document/visibilityState}} of 
+        the [=Document/visibility state=] of 
         the <code>Document</code> of the <a>top-level browsing
         context</a> changes, it MUST abort the already running <a>processing
         vibration patterns</a> algorithm, if any.


### PR DESCRIPTION
[Page Visibility Level 2](https://www.w3.org/TR/2022/DISC-page-visibility-2-20220623/) had discontinued at 2022-06-23.
Refer `{{Document/visibilityState}}` instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/pull/41.html" title="Last updated on Sep 9, 2024, 9:02 PM UTC (b4dd105)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/41/58af2d3...b4dd105.html" title="Last updated on Sep 9, 2024, 9:02 PM UTC (b4dd105)">Diff</a>