### PR TITLE
Define 'max length' and 'max duration' normatively

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,19 +145,6 @@
           </ol>
         </li>
         <li>Let <var>max length</var> have the value 10.
-          <div class='note'>
-            If the length of a pattern is greater than max length an
-            implementation of this API could consider breaking the request
-            effectively into multiple shorter requests internally to achieve
-            the same effect, rather than ignoring what follows the max length.
-            There are cases, however, where it is appropriate to ignore the
-            pattern exceeding the max length. An example is if the length is so
-            long that it would effectively create a denial of service attack on
-            the user. A web application might also make multiple requests if it
-            is known to the application that the length is too long for some
-            implementations and a possible gap in between patterns is
-            acceptable.
-          </div>
         </li>
         <li>If the length of <var>pattern</var> is greater than <var>max
         length</var>, truncate <var>pattern</var>, leaving only the first <var>

--- a/index.html
+++ b/index.html
@@ -144,8 +144,7 @@
             </li>
           </ol>
         </li>
-        <li>Let <var>max length</var> be an implementation-dependent maximum
-        length of <var>pattern</var>.
+        <li>Let <var>max length</var> have the value 10.
           <div class='note'>
             If the length of a pattern is greater than max length an
             implementation of this API could consider breaking the request
@@ -170,8 +169,7 @@
             point.
           </div>
         </li>
-        <li>Let <var>max duration</var> be an implementation-dependent maximum
-        duration for a single vibration entry in a <var>pattern</var>.
+        <li>Let <var>max duration</var> have the value 10000.
         </li>
         <li>For each entry in <var>pattern</var> whose value is greater than
         <var>max duration</var>, set the entry's value to <var>max

--- a/index.html
+++ b/index.html
@@ -297,6 +297,7 @@
         Changes since <a href="https://www.w3.org/TR/2016/REC-vibration-20161018/">W3C Recommendation 18 October 2016</a>:
       </p>
       <ul>
+        <li>Define "max length" and "max duration" normatively (<a href="https://github.com/w3c/vibration/pull/46/commits/23e6347c1cd19b50d9c356fefb6f1800330868f1">23e6347</a>, <a href="https://github.com/w3c/vibration/pull/46/commits/a3af007daf49001bb924a6d345e5dbc2a0c6d96f">a3af007</a>, <a href="https://github.com/w3c/vibration/pull/46">#46</a>)</li>
         <li>Require sticky activation to <a>perform vibration</a> to mitigate privacy concerns (<a href="https://github.com/w3c/vibration/pull/30/commits/41d039ece8a0cfb43ef7ec818dabf9156fc956d3">41d039e</a>, <a href="https://github.com/w3c/vibration/pull/30">#30</a>)</li>
         <li>Add <a>vibration pattern</a> definition for reuse in other specifications (<a href="https://github.com/w3c/vibration/pull/18/commits/b454da89ae954d4c5a6caa6c311441511349e639">b454da8</a>, <a href="https://github.com/w3c/vibration/pull/18">#18</a>)</li>
         <li>Refactor <a>perform vibration</a> algorithm to use method steps prose (<a href="https://github.com/w3c/vibration/pull/30/commits/a406e764dd4155c69a4cba4ca1ac15c7b5f47587">a406e76</a>, <a href="https://github.com/w3c/vibration/pull/30">#30</a>)</li>


### PR DESCRIPTION
Mitigates fingerprinting and tracking vectors that rely on inconsistencies across devices per W3C Security review recommendation:

https://github.com/w3c/security-request/issues/71

Note: max duration is expressed in milliseconds.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/pull/46.html" title="Last updated on Oct 21, 2024, 7:50 AM UTC (b6c9453)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/46/6aaec47...b6c9453.html" title="Last updated on Oct 21, 2024, 7:50 AM UTC (b6c9453)">Diff</a>