### PR TITLE
Enable auto-publication of CRD to /TR

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,22 @@
+# https://github.com/w3c/spec-prod/blob/main/docs/examples.md#use-different-respecconfig-when-deploying-to-w3c
+
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [gh-pages]
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-device-apis/2021May/0008.html
+          # Publish to w3.org/TR as a Candidate Recommendation Draft (CRD)
+          W3C_BUILD_OVERRIDE: |
+            specStatus: CRD
+            shortName: vibration


### PR DESCRIPTION
Adapted from:
https://github.com/w3c/spec-prod/blob/main/docs/examples.md#use-different-respecconfig-when-deploying-to-w3c

Note:
The `ECHIDNA_TOKEN` token needs to be added in the repository Settings: Settings > Security > Secrets and variables > Actions > Repository secrets

Token creation:
https://github.com/w3c/echidna/wiki/Token-creation