### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/.github/workflows/auto-publish-report.yml
+++ b/.github/workflows/auto-publish-report.yml
@@ -1,0 +1,27 @@
+name: Publish implementation report
+
+on:
+  push:
+    branches:
+      - gh-pages
+    paths:
+      - reports/implementation.html
+  pull_request:
+    paths:
+      - reports/implementation.html
+
+jobs:
+  generate-report:
+    name: Generate implementation report
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: w3c/spec-prod@v2
+        with:
+          SOURCE: reports/implementation.html
+          TOOLCHAIN: respec
+          VALIDATE_LINKS: false
+          VALIDATE_PUBRULES: false
+          GH_PAGES_BRANCH: gh-pages

--- a/implementation-report.html
+++ b/implementation-report.html
@@ -1,0 +1,373 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Vibration API — Implementation Report</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 60em;
+      margin: 2em auto;
+      padding: 0 1em;
+      color: #333;
+      line-height: 1.5;
+    }
+    h1, h2, h3 { color: #005a9c; }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 1em 0;
+      font-size: 0.9em;
+    }
+    th, td {
+      border: 1px solid #ccc;
+      padding: 0.4em 0.7em;
+      text-align: left;
+    }
+    th { background: #f0f0f0; }
+    .pass { color: #2a7a2a; font-weight: bold; }
+    .fail { color: #c00; font-weight: bold; }
+    .stub { color: #996600; font-weight: bold; }
+    .na   { color: #666; }
+    .note {
+      background: #fffbe6;
+      border-left: 4px solid #e6ac00;
+      padding: 0.5em 1em;
+      margin: 1em 0;
+    }
+    .warning {
+      background: #fff0f0;
+      border-left: 4px solid #c00;
+      padding: 0.5em 1em;
+      margin: 1em 0;
+    }
+    dl dt { font-weight: bold; margin-top: 0.8em; }
+    dl dd { margin-left: 1.5em; }
+    .engine-note { font-size: 0.85em; color: #555; }
+  </style>
+</head>
+<body>
+  <h1>Vibration API — Implementation Report</h1>
+
+  <dl>
+    <dt>Specification:</dt>
+    <dd><a href="https://www.w3.org/TR/vibration/">Vibration API</a> (W3C Candidate Recommendation)</dd>
+    <dt>Test suite:</dt>
+    <dd><a href="https://wpt.live/vibration/">https://wpt.live/vibration/</a></dd>
+    <dt>WPT results:</dt>
+    <dd><a href="https://wpt.fyi/results/vibration">https://wpt.fyi/results/vibration</a></dd>
+    <dt>Report date:</dt>
+    <dd>2026-03-31</dd>
+    <dt>Manual test data collected:</dt>
+    <dd>2024-06-08 (see <a href="https://github.com/w3c/vibration/issues/33">w3c/vibration#33</a>)</dd>
+    <dt>Report author:</dt>
+    <dd>Marcos Cáceres (<a href="https://github.com/marcoscaceres">@marcoscaceres</a>)</dd>
+  </dl>
+
+  <div class="warning">
+    <strong>Summary:</strong> The Vibration API is implemented in a single browser engine (Blink).
+    Firefox removed support in version 129 (June 2024). WebKit has never implemented
+    the API and formally opposes it. This specification does not currently meet the W3C
+    Process requirement of at least two independent interoperable implementations for
+    advancement beyond Candidate Recommendation.
+  </div>
+
+  <h2>1. Browser Engine Support</h2>
+
+  <p>
+    The following table lists <em>browser engines</em>, not individual browsers.
+    Chromium-based browsers (Chrome, Edge, Opera, Samsung Internet, WebView Android, etc.)
+    all share the Blink engine and are counted as a single implementation.
+  </p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Engine</th>
+        <th>Browsers</th>
+        <th>Status</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Blink</strong></td>
+        <td>Chrome, Edge, Opera, Samsung Internet, Chrome for Android, WebView Android, and other Chromium-based browsers</td>
+        <td class="pass">Implemented</td>
+        <td>
+          Cross-origin iframe restrictions added in Chrome 55.
+          User gesture requirement added in Chrome 60.
+          See <a href="https://chromestatus.com/feature/5698768766877696">Chrome Status</a>.
+        </td>
+      </tr>
+      <tr>
+        <td><strong>Gecko</strong></td>
+        <td>Firefox</td>
+        <td class="fail">Removed</td>
+        <td>
+          Firefox Desktop: support removed in version 129 (June 2024),
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1900037">Bug 1900037</a>.
+          Firefox for Android: API present as a stub since version 79 (returns
+          <code>true</code> for web compatibility but performs no vibration),
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1653318">Bug 1653318</a>.
+          Mozilla standards position: under consideration,
+          <a href="https://github.com/mozilla/standards-positions/issues/907">issue #907</a>.
+        </td>
+      </tr>
+      <tr>
+        <td><strong>WebKit</strong></td>
+        <td>Safari (macOS, iOS, iPadOS), all iOS/iPadOS browsers</td>
+        <td class="fail">Not implemented</td>
+        <td>
+          Never shipped. Removed from codebase in 2017 (changeset 216696).
+          WebKit formal standards position: <strong>Oppose</strong>,
+          <a href="https://github.com/WebKit/standards-positions/issues/267">issue #267</a>
+          (closed 2023-11-14). Concerns: device independence, portability,
+          annoyance/abuse potential, power consumption, integration infeasibility
+          on Apple platforms.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="note">
+    <strong>Note on Firefox for Android stub behavior:</strong>
+    Firefox for Android returns <code>true</code> from <code>navigator.vibrate()</code>
+    for web compatibility reasons, which causes automated API-presence tests to pass.
+    This does <em>not</em> represent a functional implementation: no haptic feedback
+    is produced. Manual tests confirm the API is non-functional.
+    See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1653318">Bug 1653318</a>.
+  </div>
+
+  <h2>2. Automated Test Results</h2>
+
+  <p>
+    Automated results are available at
+    <a href="https://wpt.fyi/results/vibration?label=master&amp;aligned=true">wpt.fyi/results/vibration</a>.
+    The table below reflects the pattern consistently shown by those results.
+  </p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Test</th>
+        <th>Blink (Chrome for Android)</th>
+        <th>Gecko (Firefox for Android)</th>
+        <th>WebKit (Safari iOS)</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="https://wpt.live/vibration/api-is-present.html">api-is-present.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="stub">Pass (stub)</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/idlharness.window.js">idlharness.window.js</a></td>
+        <td class="pass">Pass</td>
+        <td class="stub">Pass (stub)</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/invalid-values.html">invalid-values.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="stub">Pass (stub)</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/silent-ignore.html">silent-ignore.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="stub">Pass (stub)</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <th>Total</th>
+        <th class="pass">4 / 4</th>
+        <th class="stub">4 / 4 (stubs)</th>
+        <th class="fail">0 / 4</th>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>3. Manual Test Results</h2>
+
+  <p>
+    Manual tests were conducted on 2024-06-08 against the following browser versions:
+  </p>
+  <ul>
+    <li>Chrome for Android 125.0.6422 (Blink engine)</li>
+    <li>Firefox for Android 126.0.1 (Gecko engine)</li>
+    <li>Safari on iOS 17.4.1 (WebKit engine)</li>
+  </ul>
+  <p>
+    Manual tests verify that the vibration mechanism is actually triggered on the device.
+    These tests cannot be automated.
+  </p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Test</th>
+        <th>Blink (Chrome for Android 125)</th>
+        <th>Gecko (Firefox for Android 126)</th>
+        <th>WebKit (Safari iOS 17.4.1)</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="https://wpt.live/vibration/cancel-when-hidden-manual.html">cancel-when-hidden-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/cancel-with-0-manual.html">cancel-with-0-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/cancel-with-array-0-manual.html">cancel-with-array-0-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/cancel-with-empty-array-manual.html">cancel-with-empty-array-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/cancel-with-new-manual.html">cancel-with-new-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/pattern-array-extra-manual.html">pattern-array-extra-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/pattern-array-manual.html">pattern-array-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/pattern-array-with-0-manual.html">pattern-array-with-0-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/simple-array-manual.html">simple-array-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <td><a href="https://wpt.live/vibration/simple-scalar-manual.html">simple-scalar-manual.html</a></td>
+        <td class="pass">Pass</td>
+        <td class="fail">Fail</td>
+        <td class="fail">Fail</td>
+      </tr>
+      <tr>
+        <th>Total</th>
+        <th class="pass">10 / 10</th>
+        <th class="fail">0 / 10</th>
+        <th class="fail">0 / 10</th>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>4. Implementation Experience (W3C Process)</h2>
+
+  <p>
+    The following addresses the
+    <a href="https://www.w3.org/policies/process/#implementation-experience">W3C Process
+    implementation experience criteria</a>.
+  </p>
+
+  <dl>
+    <dt>Is each feature of the specification implemented?</dt>
+    <dd>
+      All features are implemented in the Blink engine (Chrome for Android, Chrome desktop,
+      Edge, and other Chromium-based browsers). No other engine provides a functional
+      implementation.
+    </dd>
+
+    <dt>Are there independent interoperable implementations of each feature?</dt>
+    <dd>
+      <strong>No.</strong> Only one browser engine (Blink) provides a functional
+      implementation. Firefox removed support in version 129. WebKit has never
+      implemented the API and formally opposes it. The stub behavior in Firefox for
+      Android does not constitute an interoperable implementation: the API returns
+      <code>true</code> but produces no vibration.
+    </dd>
+
+    <dt>Are the implementations by different, independent developers?</dt>
+    <dd>
+      The Chromium-based implementations (Chrome, Edge, Opera, Samsung Internet, etc.)
+      share the same Blink engine codebase and are not independent of each other.
+      They represent a single implementation.
+    </dd>
+
+    <dt>Are the implementations deployed on production systems?</dt>
+    <dd>
+      Yes, in Chromium-based browsers. Not in Firefox (removed) or Safari (never shipped).
+    </dd>
+
+    <dt>Is there implementation experience of the complete specification?</dt>
+    <dd>
+      The complete specification is implemented only in Blink. As noted above, this
+      constitutes a single-engine implementation.
+    </dd>
+
+    <dt>Have any difficulties or problems been reported during implementation?</dt>
+    <dd>
+      Yes. Chrome introduced user gesture requirements (v60) and cross-origin iframe
+      restrictions (v55) in response to widespread abuse of the API by advertisers and
+      low-quality sites. Chrome use counter data (2022–2024) showed 0.06–0.08% usage,
+      concentrated in low-quality content. Firefox disabled the API in Firefox for
+      Android citing abuse concerns before removing it entirely from Firefox Desktop
+      in v129 (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1900037">Bug 1900037</a>).
+      WebKit's opposition cites device independence, power consumption, annoyance/abuse
+      potential, portability, and infeasibility of integration on Apple platforms
+      (<a href="https://github.com/WebKit/standards-positions/issues/267">WebKit standards position #267</a>).
+    </dd>
+  </dl>
+
+  <h2>5. Conclusion</h2>
+
+  <p>
+    The Vibration API has a single functional browser engine implementation (Blink).
+    It does not meet the W3C Process requirement of at least two independent interoperable
+    implementations for advancement beyond Candidate Recommendation to Recommendation.
+  </p>
+  <p>
+    This report was produced to fulfill the recommendation of the W3C Council
+    (<a href="https://www.w3.org/2025/08/vibration2-council-report.html#recommendations">Vibration
+    API Council Report, August 2025</a>) that the WG document what implementation
+    experience the API currently has.
+  </p>
+
+  <h2>6. References</h2>
+
+  <ul>
+    <li><a href="https://www.w3.org/TR/vibration/">Vibration API specification</a></li>
+    <li><a href="https://wpt.fyi/results/vibration">WPT results: vibration</a></li>
+    <li><a href="https://wpt.live/vibration/">WPT test suite: vibration</a></li>
+    <li><a href="https://github.com/w3c/vibration/issues/33">w3c/vibration#33: Update implementation report</a></li>
+    <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1900037">Bugzilla 1900037: Disable broken vibration APIs (RESOLVED FIXED)</a></li>
+    <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1653318">Bugzilla 1653318: Decide what to do with navigator.vibrate()</a></li>
+    <li><a href="https://github.com/WebKit/standards-positions/issues/267">WebKit standards position: Vibration API (Oppose)</a></li>
+    <li><a href="https://github.com/mozilla/standards-positions/issues/907">Mozilla standards position: Vibration API (Under consideration)</a></li>
+    <li><a href="https://www.w3.org/2025/08/vibration2-council-report.html">W3C Council Report on Vibration API (August 2025)</a></li>
+    <li><a href="https://caniuse.com/vibration">Can I Use: Vibration API</a></li>
+  </ul>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           group:        "das",
           wgPublicList: "public-device-apis",
           testSuiteURI: "https://wpt.live/vibration/",
-          implementationReportURI: "https://wpt.fyi/results/vibration",
+          implementationReportURI: "implementation-report.html",
           processVersion: 2023,
           xref: {
             profile: "web-platform"

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           group:        "das",
           wgPublicList: "public-device-apis",
           testSuiteURI: "https://wpt.live/vibration/",
-          implementationReportURI: "implementation-report.html",
+          implementationReportURI: "reports/implementation.html",
           processVersion: 2023,
           xref: {
             profile: "web-platform"

--- a/index.html
+++ b/index.html
@@ -49,6 +49,13 @@
       mechanism of the hosting device. Vibration is a form of tactile feedback.
     </section>
     <section id='sotd'>
+      <div class="advisement">
+        This specification is currently implemented in a single browser engine (Blink).
+        Gecko implemented this API but removed it in version 129.
+        Implementer standards positions:
+        <a href="https://github.com/WebKit/standards-positions/issues/267">WebKit</a>,
+        <a href="https://github.com/mozilla/standards-positions/issues/907">Mozilla</a>.
+      </div>
       <p>
         This document represents the consensus of the group on the scope and
         features of the Vibration API. It should be noted that the group is

--- a/reports/implementation.html
+++ b/reports/implementation.html
@@ -105,12 +105,12 @@
         <td>Firefox</td>
         <td class="fail">Removed</td>
         <td>
-          Firefox Desktop: support removed in version 129 (June 2024),
+          Firefox Desktop: support removed in version 129 (August 6, 2024),
           <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1900037">Bug 1900037</a>.
           Firefox for Android: API present as a stub since version 79 (returns
           <code>true</code> for web compatibility but performs no vibration),
           <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1653318">Bug 1653318</a>.
-          Mozilla standards position: under consideration,
+          Mozilla standards position: open, no position assigned,
           <a href="https://github.com/mozilla/standards-positions/issues/907">issue #907</a>.
         </td>
       </tr>

--- a/reports/implementation.html
+++ b/reports/implementation.html
@@ -1,103 +1,100 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Vibration API — Implementation Report</title>
-  <style>
-    body {
-      font-family: sans-serif;
-      max-width: 60em;
-      margin: 2em auto;
-      padding: 0 1em;
-      color: #333;
-      line-height: 1.5;
-    }
-    h1, h2, h3 { color: #005a9c; }
-    table {
-      border-collapse: collapse;
-      width: 100%;
-      margin: 1em 0;
-      font-size: 0.9em;
-    }
-    th, td {
-      border: 1px solid #ccc;
-      padding: 0.4em 0.7em;
-      text-align: left;
-    }
-    th { background: #f0f0f0; }
-    .pass { color: #2a7a2a; font-weight: bold; }
-    .fail { color: #c00; font-weight: bold; }
-    .stub { color: #996600; font-weight: bold; }
-    .na   { color: #666; }
-    .note {
-      background: #fffbe6;
-      border-left: 4px solid #e6ac00;
-      padding: 0.5em 1em;
-      margin: 1em 0;
-    }
-    .warning {
-      background: #fff0f0;
-      border-left: 4px solid #c00;
-      padding: 0.5em 1em;
-      margin: 1em 0;
-    }
-    dl dt { font-weight: bold; margin-top: 0.8em; }
-    dl dd { margin-left: 1.5em; }
-    .engine-note { font-size: 0.85em; color: #555; }
-  </style>
-</head>
-<body>
-  <h1>Vibration API — Implementation Report</h1>
-
-  <dl>
-    <dt>Specification:</dt>
-    <dd><a href="https://www.w3.org/TR/vibration/">Vibration API</a> (W3C Candidate Recommendation)</dd>
-    <dt>Test suite:</dt>
-    <dd><a href="https://wpt.live/vibration/">https://wpt.live/vibration/</a></dd>
-    <dt>WPT results:</dt>
-    <dd><a href="https://wpt.fyi/results/vibration">https://wpt.fyi/results/vibration</a></dd>
-    <dt>Report date:</dt>
-    <dd>2026-03-31</dd>
-    <dt>Manual test data collected:</dt>
-    <dd>2024-06-08 (see <a href="https://github.com/w3c/vibration/issues/33">w3c/vibration#33</a>)</dd>
-    <dt>Report author:</dt>
-    <dd>Marcos Cáceres (<a href="https://github.com/marcoscaceres">@marcoscaceres</a>)</dd>
-  </dl>
-
-  <div class="warning">
-    <strong>Summary:</strong> The Vibration API is implemented in a single browser engine (Blink).
-    Firefox removed support in version 129 (June 2024). WebKit has never implemented
-    the API and formally opposes it. This specification does not currently meet the W3C
-    Process requirement of at least two independent interoperable implementations for
-    advancement beyond Candidate Recommendation.
-  </div>
-
-  <h2>1. Browser Engine Support</h2>
-
-  <p>
-    The following table lists <em>browser engines</em>, not individual browsers.
-    Chromium-based browsers (Chrome, Edge, Opera, Samsung Internet, WebView Android, etc.)
-    all share the Blink engine and are counted as a single implementation.
-  </p>
-
-  <table>
-    <thead>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" async class=
+    "remove"></script>
+    <script class="remove">
+      // All config options at https://respec.org/docs/
+      var respecConfig = {
+        specStatus: "base",
+        editors: [
+          {
+            name: "Marcos Cáceres",
+            company: "Apple",
+            w3cid: "85615",
+          },
+        ],
+        latestVersion: null,
+        xref: "web-platform",
+      };
+    </script>
+    <style>
+      .pass,
+      .fail,
+      .stub {
+        color: white;
+      }
+      .pass {
+        background-color: green;
+      }
+      .fail {
+        background-color: red;
+      }
+      .stub {
+        background-color: #795548;
+      }
+      .pass a,
+      .pass a:link,
+      .pass a:visited,
+      .fail a,
+      .fail a:link,
+      .fail a:visited,
+      .stub a,
+      .stub a:link,
+      .stub a:visited {
+        color: white !important;
+        text-decoration: underline;
+      }
+    </style>
+    <title>
+      Vibration API - Implementation Report
+    </title>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>
+        This is an implementation report for the [[vibration]] specification,
+        produced in response to the W3C Council recommendation
+        (<a href="https://www.w3.org/2025/08/vibration2-council-report.html#recommendations">
+        Vibration API Council Report, August 2025</a>) that the Working Group
+        document what implementation experience the API currently has.
+      </p>
+      <p>
+        The Vibration API is implemented in a single browser engine (Blink).
+        Firefox (Gecko) removed support in version 129 (August 6, 2024).
+        WebKit has never implemented the API and formally opposes it.
+      </p>
+    </section>
+    <h2>
+      Browser engine support
+    </h2>
+    <p>
+      The following table lists <em>browser engines</em>, not individual
+      browsers. Chromium-based browsers (Chrome, Edge, Opera, Samsung Internet,
+      WebView Android, etc.) all share the Blink engine and are counted as a
+      single implementation.
+    </p>
+    <table class="simple data">
+      <caption>
+        Browser engine implementation status for [[vibration]]
+      </caption>
       <tr>
         <th>Engine</th>
         <th>Browsers</th>
         <th>Status</th>
         <th>Notes</th>
       </tr>
-    </thead>
-    <tbody>
       <tr>
         <td><strong>Blink</strong></td>
-        <td>Chrome, Edge, Opera, Samsung Internet, Chrome for Android, WebView Android, and other Chromium-based browsers</td>
+        <td>Chrome, Edge, Opera, Samsung Internet, Chrome for Android,
+        WebView Android, and other Chromium-based browsers</td>
         <td class="pass">Implemented</td>
         <td>
           Cross-origin iframe restrictions added in Chrome 55.
           User gesture requirement added in Chrome 60.
-          See <a href="https://chromestatus.com/feature/5698768766877696">Chrome Status</a>.
+          See <a href="https://chromestatus.com/feature/5698768766877696">
+          Chrome Status</a>.
         </td>
       </tr>
       <tr>
@@ -106,12 +103,16 @@
         <td class="fail">Removed</td>
         <td>
           Firefox Desktop: support removed in version 129 (August 6, 2024),
-          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1900037">Bug 1900037</a>.
-          Firefox for Android: API present as a stub since version 79 (returns
-          <code>true</code> for web compatibility but performs no vibration),
-          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1653318">Bug 1653318</a>.
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1900037">Bug
+          1900037</a>.
+          Firefox for Android: API present as a stub since version 79
+          (returns <code>true</code> for web compatibility but performs no
+          vibration),
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1653318">Bug
+          1653318</a>.
           Mozilla standards position: open, no position assigned,
-          <a href="https://github.com/mozilla/standards-positions/issues/907">issue #907</a>.
+          <a href="https://github.com/mozilla/standards-positions/issues/907">
+          issue #907</a>.
         </td>
       </tr>
       <tr>
@@ -121,253 +122,267 @@
         <td>
           Never shipped. Removed from codebase in 2017 (changeset 216696).
           WebKit formal standards position: <strong>Oppose</strong>,
-          <a href="https://github.com/WebKit/standards-positions/issues/267">issue #267</a>
-          (closed 2023-11-14). Concerns: device independence, portability,
-          annoyance/abuse potential, power consumption, integration infeasibility
-          on Apple platforms.
+          <a href="https://github.com/WebKit/standards-positions/issues/267">
+          issue #267</a> (closed 2023-11-14). Concerns: device independence,
+          portability, annoyance/abuse potential, power consumption,
+          integration infeasibility on Apple platforms.
         </td>
       </tr>
-    </tbody>
-  </table>
-
-  <div class="note">
-    <strong>Note on Firefox for Android stub behavior:</strong>
-    Firefox for Android returns <code>true</code> from <code>navigator.vibrate()</code>
-    for web compatibility reasons, which causes automated API-presence tests to pass.
-    This does <em>not</em> represent a functional implementation: no haptic feedback
-    is produced. Manual tests confirm the API is non-functional.
-    See <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1653318">Bug 1653318</a>.
-  </div>
-
-  <h2>2. Automated Test Results</h2>
-
-  <p>
-    Automated results are available at
-    <a href="https://wpt.fyi/results/vibration?label=master&amp;aligned=true">wpt.fyi/results/vibration</a>.
-    The table below reflects the pattern consistently shown by those results.
-  </p>
-
-  <table>
-    <thead>
+    </table>
+    <h2>
+      Test results
+    </h2>
+    <p>
+      The following tests verify conformance to [[vibration]].
+    </p>
+    <p class="note">
+      For the latest automated test results, visit
+      <a href="https://wpt.fyi/results/vibration">wpt.fyi/results/vibration</a>.
+    </p>
+    <h3>
+      Status legend
+    </h3>
+    <dl>
+      <dt>PASS</dt>
+      <dd>
+        The test ran successfully and the implementation conforms to the
+        specification.
+      </dd>
+      <dt>FAIL</dt>
+      <dd>
+        The test ran and the implementation does not conform to the
+        specification.
+      </dd>
+      <dt>STUB</dt>
+      <dd>
+        The test passed because the API is present and returns a value, but
+        the underlying functionality is not implemented. For Firefox for
+        Android, <code>navigator.vibrate()</code> returns <code>true</code>
+        for web compatibility but produces no haptic feedback. This does not
+        constitute a conforming implementation.
+      </dd>
+    </dl>
+    <h3>
+      Automated test results
+    </h3>
+    <table class="simple data">
+      <caption>
+        Automated WPT results for [[vibration]]
+      </caption>
       <tr>
         <th>Test</th>
         <th>Blink (Chrome for Android)</th>
         <th>Gecko (Firefox for Android)</th>
         <th>WebKit (Safari iOS)</th>
       </tr>
-    </thead>
-    <tbody>
       <tr>
-        <td><a href="https://wpt.live/vibration/api-is-present.html">api-is-present.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="stub">Pass (stub)</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/api-is-present.html">
+          api-is-present.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="stub">STUB</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/idlharness.window.js">idlharness.window.js</a></td>
-        <td class="pass">Pass</td>
-        <td class="stub">Pass (stub)</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/idlharness.window.js">
+          idlharness.window.js</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="stub">STUB</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/invalid-values.html">invalid-values.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="stub">Pass (stub)</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/invalid-values.html">
+          invalid-values.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="stub">STUB</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/silent-ignore.html">silent-ignore.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="stub">Pass (stub)</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/silent-ignore.html">
+          silent-ignore.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="stub">STUB</td>
+        <td class="fail">FAIL</td>
       </tr>
-      <tr>
-        <th>Total</th>
-        <th class="pass">4 / 4</th>
-        <th class="stub">4 / 4 (stubs)</th>
-        <th class="fail">0 / 4</th>
-      </tr>
-    </tbody>
-  </table>
-
-  <h2>3. Manual Test Results</h2>
-
-  <p>
-    Manual tests were conducted on 2024-06-08 against the following browser versions:
-  </p>
-  <ul>
-    <li>Chrome for Android 125.0.6422 (Blink engine)</li>
-    <li>Firefox for Android 126.0.1 (Gecko engine)</li>
-    <li>Safari on iOS 17.4.1 (WebKit engine)</li>
-  </ul>
-  <p>
-    Manual tests verify that the vibration mechanism is actually triggered on the device.
-    These tests cannot be automated.
-  </p>
-
-  <table>
-    <thead>
+    </table>
+    <h3>
+      Manual test results
+    </h3>
+    <p>
+      Manual tests verify that the vibration mechanism is actually triggered
+      on the device. These tests cannot be automated. Tests were conducted on
+      2024-06-08 (see
+      <a href="https://github.com/w3c/vibration/issues/33">w3c/vibration#33</a>)
+      against the following browser versions:
+    </p>
+    <ul>
+      <li>Chrome for Android 125.0.6422 (Blink engine)</li>
+      <li>Firefox for Android 126.0.1 (Gecko engine)</li>
+      <li>Safari on iOS 17.4.1 (WebKit engine)</li>
+    </ul>
+    <table class="simple data">
+      <caption>
+        Manual WPT results for [[vibration]]
+      </caption>
       <tr>
         <th>Test</th>
         <th>Blink (Chrome for Android 125)</th>
         <th>Gecko (Firefox for Android 126)</th>
         <th>WebKit (Safari iOS 17.4.1)</th>
       </tr>
-    </thead>
-    <tbody>
       <tr>
-        <td><a href="https://wpt.live/vibration/cancel-when-hidden-manual.html">cancel-when-hidden-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/cancel-when-hidden-manual.html">
+          cancel-when-hidden-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/cancel-with-0-manual.html">cancel-with-0-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/cancel-with-0-manual.html">
+          cancel-with-0-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/cancel-with-array-0-manual.html">cancel-with-array-0-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/cancel-with-array-0-manual.html">
+          cancel-with-array-0-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/cancel-with-empty-array-manual.html">cancel-with-empty-array-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href=
+          "https://wpt.live/vibration/cancel-with-empty-array-manual.html">
+          cancel-with-empty-array-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/cancel-with-new-manual.html">cancel-with-new-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/cancel-with-new-manual.html">
+          cancel-with-new-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/pattern-array-extra-manual.html">pattern-array-extra-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href=
+          "https://wpt.live/vibration/pattern-array-extra-manual.html">
+          pattern-array-extra-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/pattern-array-manual.html">pattern-array-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/pattern-array-manual.html">
+          pattern-array-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/pattern-array-with-0-manual.html">pattern-array-with-0-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href=
+          "https://wpt.live/vibration/pattern-array-with-0-manual.html">
+          pattern-array-with-0-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/simple-array-manual.html">simple-array-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/simple-array-manual.html">
+          simple-array-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
       <tr>
-        <td><a href="https://wpt.live/vibration/simple-scalar-manual.html">simple-scalar-manual.html</a></td>
-        <td class="pass">Pass</td>
-        <td class="fail">Fail</td>
-        <td class="fail">Fail</td>
+        <td>
+          <a href="https://wpt.live/vibration/simple-scalar-manual.html">
+          simple-scalar-manual.html</a>
+        </td>
+        <td class="pass">PASS</td>
+        <td class="fail">FAIL</td>
+        <td class="fail">FAIL</td>
       </tr>
-      <tr>
-        <th>Total</th>
-        <th class="pass">10 / 10</th>
-        <th class="fail">0 / 10</th>
-        <th class="fail">0 / 10</th>
-      </tr>
-    </tbody>
-  </table>
-
-  <h2>4. Implementation Experience (W3C Process)</h2>
-
-  <p>
-    The following addresses the
-    <a href="https://www.w3.org/policies/process/#implementation-experience">W3C Process
-    implementation experience criteria</a>.
-  </p>
-
-  <dl>
-    <dt>Is each feature of the specification implemented?</dt>
-    <dd>
-      All features are implemented in the Blink engine (Chrome for Android, Chrome desktop,
-      Edge, and other Chromium-based browsers). No other engine provides a functional
-      implementation.
-    </dd>
-
-    <dt>Are there independent interoperable implementations of each feature?</dt>
-    <dd>
-      <strong>No.</strong> Only one browser engine (Blink) provides a functional
-      implementation. Firefox removed support in version 129. WebKit has never
-      implemented the API and formally opposes it. The stub behavior in Firefox for
-      Android does not constitute an interoperable implementation: the API returns
-      <code>true</code> but produces no vibration.
-    </dd>
-
-    <dt>Are the implementations by different, independent developers?</dt>
-    <dd>
-      The Chromium-based implementations (Chrome, Edge, Opera, Samsung Internet, etc.)
-      share the same Blink engine codebase and are not independent of each other.
-      They represent a single implementation.
-    </dd>
-
-    <dt>Are the implementations deployed on production systems?</dt>
-    <dd>
-      Yes, in Chromium-based browsers. Not in Firefox (removed) or Safari (never shipped).
-    </dd>
-
-    <dt>Is there implementation experience of the complete specification?</dt>
-    <dd>
-      The complete specification is implemented only in Blink. As noted above, this
-      constitutes a single-engine implementation.
-    </dd>
-
-    <dt>Have any difficulties or problems been reported during implementation?</dt>
-    <dd>
-      Yes. Chrome introduced user gesture requirements (v60) and cross-origin iframe
-      restrictions (v55) in response to widespread abuse of the API by advertisers and
-      low-quality sites. Chrome use counter data (2022–2024) showed 0.06–0.08% usage,
-      concentrated in low-quality content. Firefox disabled the API in Firefox for
-      Android citing abuse concerns before removing it entirely from Firefox Desktop
-      in v129 (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1900037">Bug 1900037</a>).
-      WebKit's opposition cites device independence, power consumption, annoyance/abuse
-      potential, portability, and infeasibility of integration on Apple platforms
-      (<a href="https://github.com/WebKit/standards-positions/issues/267">WebKit standards position #267</a>).
-    </dd>
-  </dl>
-
-  <h2>5. Conclusion</h2>
-
-  <p>
-    The Vibration API has a single functional browser engine implementation (Blink).
-    It does not meet the W3C Process requirement of at least two independent interoperable
-    implementations for advancement beyond Candidate Recommendation to Recommendation.
-  </p>
-  <p>
-    This report was produced to fulfill the recommendation of the W3C Council
-    (<a href="https://www.w3.org/2025/08/vibration2-council-report.html#recommendations">Vibration
-    API Council Report, August 2025</a>) that the WG document what implementation
-    experience the API currently has.
-  </p>
-
-  <h2>6. References</h2>
-
-  <ul>
-    <li><a href="https://www.w3.org/TR/vibration/">Vibration API specification</a></li>
-    <li><a href="https://wpt.fyi/results/vibration">WPT results: vibration</a></li>
-    <li><a href="https://wpt.live/vibration/">WPT test suite: vibration</a></li>
-    <li><a href="https://github.com/w3c/vibration/issues/33">w3c/vibration#33: Update implementation report</a></li>
-    <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1900037">Bugzilla 1900037: Disable broken vibration APIs (RESOLVED FIXED)</a></li>
-    <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1653318">Bugzilla 1653318: Decide what to do with navigator.vibrate()</a></li>
-    <li><a href="https://github.com/WebKit/standards-positions/issues/267">WebKit standards position: Vibration API (Oppose)</a></li>
-    <li><a href="https://github.com/mozilla/standards-positions/issues/907">Mozilla standards position: Vibration API (Under consideration)</a></li>
-    <li><a href="https://www.w3.org/2025/08/vibration2-council-report.html">W3C Council Report on Vibration API (August 2025)</a></li>
-    <li><a href="https://caniuse.com/vibration">Can I Use: Vibration API</a></li>
-  </ul>
-</body>
+    </table>
+    <h2>
+      Is each feature of the current specification implemented, and how is
+      this demonstrated?
+    </h2>
+    <p>
+      All features of [[vibration]] are implemented in the Blink engine (Chrome
+      for Android, Chrome desktop, Edge, and other Chromium-based browsers).
+      This is demonstrated through the automated and manual WPT results above.
+      No other engine provides a functional implementation.
+    </p>
+    <h2>
+      Are there independent interoperable implementations of each feature?
+    </h2>
+    <p>
+      <strong>No.</strong> Only one browser engine (Blink) provides a
+      functional implementation. Firefox removed support in version 129
+      (August 6, 2024). WebKit has never implemented the API and formally
+      opposes it. The stub behavior in Firefox for Android does not constitute
+      an interoperable implementation: the API returns <code>true</code> but
+      produces no vibration.
+    </p>
+    <h2>
+      Are the implementations by different, independent developers?
+    </h2>
+    <p>
+      The Chromium-based implementations (Chrome, Edge, Opera, Samsung
+      Internet, etc.) share the same Blink engine codebase and are not
+      independent of each other. They represent a single implementation.
+    </p>
+    <h2>
+      Are the implementations deployed on production systems?
+    </h2>
+    <p>
+      Yes, in Chromium-based browsers. Not in Firefox (removed) or Safari
+      (never shipped).
+    </p>
+    <h2>
+      Are there reports of difficulties or problems with implementation?
+    </h2>
+    <p>
+      Yes. Chrome introduced user gesture requirements (v60) and cross-origin
+      iframe restrictions (v55) in response to widespread abuse of the API by
+      advertisers and low-quality sites. Chrome use counter data (2022-2024)
+      showed 0.06-0.08% usage, concentrated in low-quality content. Firefox
+      disabled the API in Firefox for Android citing abuse concerns before
+      removing it entirely from Firefox Desktop in v129
+      (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1900037">Bug
+      1900037</a>). WebKit's opposition cites device independence, power
+      consumption, annoyance/abuse potential, portability, and infeasibility
+      of integration on Apple platforms
+      (<a href="https://github.com/WebKit/standards-positions/issues/267">
+      WebKit standards position #267</a>).
+    </p>
+  </body>
 </html>


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/vibration/pull/56.html" title="Last updated on Mar 31, 2026, 4:56 AM UTC (eb3b21a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/56/baf3eb2...marcoscaceres:eb3b21a.html" title="Last updated on Mar 31, 2026, 4:56 AM UTC (eb3b21a)">Diff</a>