### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,13 @@
       mechanism of the hosting device. Vibration is a form of tactile feedback.
     </section>
     <section id='sotd'>
+      <div class="advisement">
+        This specification is currently implemented in a single browser engine (Blink).
+        Gecko implemented this API but removed it in version 129.
+        Implementer standards positions:
+        <a href="https://github.com/WebKit/standards-positions/issues/267">WebKit</a>,
+        <a href="https://github.com/mozilla/standards-positions/issues/907">Mozilla</a>.
+      </div>
       <p>
         This document represents the consensus of the group on the scope and
         features of the Vibration API. It should be noted that the group is


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/vibration/pull/57.html" title="Last updated on Mar 31, 2026, 5:01 AM UTC (2d2eb05)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/57/baf3eb2...marcoscaceres:2d2eb05.html" title="Last updated on Mar 31, 2026, 5:01 AM UTC (2d2eb05)">Diff</a>