### PR TITLE
Specify full implementation report URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           group:        "das",
           wgPublicList: "public-device-apis",
           testSuiteURI: "https://wpt.live/vibration/",
-          implementationReportURI: "reports/implementation.html",
+          implementationReportURI: "https://w3c.github.io/vibration/reports/implementation.html",
           processVersion: 2023,
           xref: {
             profile: "web-platform"


### PR DESCRIPTION
Specberus requires the implementation report start with https://.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/pull/58.html" title="Last updated on May 1, 2026, 11:00 PM UTC (75776ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/58/6f3e960...75776ce.html" title="Last updated on May 1, 2026, 11:00 PM UTC (75776ce)">Diff</a>