### PR TITLE
Remove GH_PAGES_BRANCH from implementation report workflow

### DIFF
--- a/.github/workflows/auto-publish-report.yml
+++ b/.github/workflows/auto-publish-report.yml
@@ -23,6 +23,5 @@ jobs:
           SOURCE: reports/implementation.html
           TOOLCHAIN: respec
           VALIDATE_LINKS: false
-          GH_PAGES_BRANCH: gh-pages
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-device-apis/2021May/0008.html


### PR DESCRIPTION
This is publishing to Echidna so it doesn't need to specify the GH_PAGES_BRANCH.