### PR TITLE
Add Baseline implementation status to spec header

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
           testSuiteURI: "https://wpt.live/vibration/",
           implementationReportURI: "https://wpt.fyi/results/vibration",
           processVersion: 2023,
+          implementationStatus: true,
           xref: {
             profile: "web-platform"
           },


### PR DESCRIPTION
Closes #63

Adds `implementationStatus: true` to the ReSpec config, which displays a Baseline browser support badge in the spec header showing current implementation status from web-features data.

The Vibration API currently shows "Limited availability" (Chrome and Edge support, no Firefox or Safari).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/vibration/pull/64.html" title="Last updated on May 11, 2026, 3:14 AM UTC (27ccfd1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/64/baf3eb2...marcoscaceres:27ccfd1.html" title="Last updated on May 11, 2026, 3:14 AM UTC (27ccfd1)">Diff</a>