### PR TITLE
Add implementation status note to SotD

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,9 @@
       mechanism of the hosting device. Vibration is a form of tactile feedback.
     </section>
     <section id='sotd'>
+      <p class="advisement">
+        This specification is implemented in Chromium-based browsers. WebKit has <a href="https://github.com/WebKit/standards-positions/issues/267">published a position opposing this specification</a>. Firefox <a href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vibrate#browser_compatibility">removed its implementation in version 129</a>. It is not expected to advance to W3C Recommendation in its current form.
+      </p>
       <p>
         This document represents the consensus of the group on the scope and
         features of the Vibration API. It should be noted that the group is


### PR DESCRIPTION
Addresses the TAG's 'at a glance' concern in design-reviews#1187.

The paragraph uses `<p class="advisement">` so it renders as a highlighted box, making the implementation-status signal visible at a glance rather than blending into the SotD boilerplate.

Reviewed in fork by @marcoscaceres and @jyasskin: https://github.com/christianliebel/vibration/pull/1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/vibration/pull/65.html" title="Last updated on May 14, 2026, 11:48 AM UTC (ea8991c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vibration/65/e9d7ae2...christianliebel:ea8991c.html" title="Last updated on May 14, 2026, 11:48 AM UTC (ea8991c)">Diff</a>