### PR TITLE
IR to /TR/ via GHAction

### DIFF
--- a/.github/workflows/auto-publish-report.yml
+++ b/.github/workflows/auto-publish-report.yml
@@ -5,10 +5,7 @@ on:
     branches:
       - gh-pages
     paths:
-      - reports/implementation.html
-  pull_request:
-    paths:
-      - reports/implementation.html
+      - reports/implementation-respec.html
 
 jobs:
   generate-report:
@@ -20,8 +17,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: reports/implementation.html
+          SOURCE: reports/implementation-respec.html
           TOOLCHAIN: respec
-          VALIDATE_LINKS: false
-          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-device-apis/2021May/0008.html
+          DESTINATION: reports/implementation.html

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -5,6 +5,9 @@ on:
   pull_request: {}
   push:
     branches: [gh-pages]
+    paths:
+      - index.html
+      - reports/implementation.html
 jobs:
   main:
     name: Build, Validate and Deploy

--- a/reports/implementation-respec.html
+++ b/reports/implementation-respec.html
@@ -7,9 +7,10 @@
     <script class="remove">
       // All config options at https://respec.org/docs/
       var respecConfig = {
-        specStatus: "DNOTE",
+        specStatus: "base",
         shortName: "vibration-implementation-report",
-        group: "das",
+        edDraftURI: "https://w3c.github.io/vibration/reports/implementation.html",
+        // latestVersion: "https://www.w3.org/TR/vibration/reports/implementation.html",
         editors: [
           {
             name: "Reilly Grant",


### PR DESCRIPTION
closes #62 

- hope should work, first auto-publish-report updates `reports/implementation.html` in gh-pages, which trigger auto-publish to update /TR/ publication
- if filename of `reports/implementation.html` is confusing per auto generated asset, please rename (like reports/implementation-build.html or else?)
- omit latestVersion per respec restriction that base cannot have /TR/ canonical URI